### PR TITLE
Fixed AccessType Enum Usage, CommandRecommendIndex calls IndexRecommender.recommendIndex()

### DIFF
--- a/src/main/java/smallsql/database/Command.java
+++ b/src/main/java/smallsql/database/Command.java
@@ -73,14 +73,14 @@ abstract class Command {
 
     /**
      * Adds the field pairs under the columnPairs arraylist to the fieldsUsed
-     * instance variable under the given operation type.
-     * @param operationType: Operation type as defined by the operation type enum
+     * instance variable under the given access type
+     * @param accessType: Access type as defined by the AccessType enum
      * @param columnPairs: Arraylist of Tablename, columnname pairs
      */
-	protected void addFields(int operationType, ArrayList<String[]> columnPairs){
+	protected void addFields(AccessType accessType, ArrayList<String[]> columnPairs){
 	    for (int i = 0; i < columnPairs.size(); i++){
 	        String[] columnPair = columnPairs.get(i);
-	        fieldsUsed.add(new TrackerRecord(operationType, columnPair[0], columnPair[1]));
+	        fieldsUsed.add(new TrackerRecord(accessType, columnPair[0], columnPair[1]));
         }
     }
 
@@ -167,7 +167,7 @@ abstract class Command {
 
     public void finalizeColumns(FieldTracker ft){
 	    for (TrackerRecord tr : fieldsUsed){
-	        ft.incrementCounter(tr.getOperationType(), tr.getTableName(), tr.getFieldName());
+	        ft.incrementCounter(tr.getAccessType(), tr.getTableName(), tr.getFieldName());
         }
     }
 
@@ -177,7 +177,7 @@ abstract class Command {
      */
     public void printFieldsUsed(){
         for (TrackerRecord tr: fieldsUsed){
-             String sf = format("Operation: %d; Table: %s; Field: %s", tr.getOperationType(), tr.getTableName(), tr.getFieldName());
+             String sf = format("Operation: %d; Table: %s; Field: %s", tr.getAccessType(), tr.getTableName(), tr.getFieldName());
              System.out.println(sf);
         }
     }

--- a/src/main/java/smallsql/database/CommandDelete.java
+++ b/src/main/java/smallsql/database/CommandDelete.java
@@ -50,7 +50,7 @@ class CommandDelete extends CommandSelect {
 	 * Gets the Table from which to Delete
 	 */
 	public void preCompileGetColumns(){
-		fieldsUsed.add(new TrackerRecord(AccessType.DELETION.ordinal(), from.getName(), null));
+		fieldsUsed.add(new TrackerRecord(AccessType.DELETION, from.getName(), null));
 	}
 
 	/**

--- a/src/main/java/smallsql/database/CommandInsert.java
+++ b/src/main/java/smallsql/database/CommandInsert.java
@@ -116,7 +116,7 @@ public class CommandInsert extends Command {
      * column name
      */
     public void postCompileGetColumns(){
-        fieldsUsed.add(new TrackerRecord(AccessType.INSERTION.ordinal(), table.getName(), null));
+        fieldsUsed.add(new TrackerRecord(AccessType.INSERTION, table.getName(), null));
     }
 
 

--- a/src/main/java/smallsql/database/CommandRecommendIndex.java
+++ b/src/main/java/smallsql/database/CommandRecommendIndex.java
@@ -7,11 +7,6 @@ public class CommandRecommendIndex extends Command {
 
     private IndexRecommender rec;
 
-    CommandRecommendIndex(Logger log) {
-        super(log);
-        this.rec = null;
-    }
-
     CommandRecommendIndex(Logger log, IndexRecommender rec) {
         super(log);
         this.rec = rec;
@@ -21,7 +16,6 @@ public class CommandRecommendIndex extends Command {
     void executeImpl(SSConnection con, SSStatement st) throws Exception {
         // check if session?
         // TODO: do this in CLI, not this class
-        System.out.println("TODO: recommend an index");
-        //System.out.println(rec.getRecommendedIndexes());
+        System.out.println(rec.recommendIndex());
     }
 }

--- a/src/main/java/smallsql/database/CommandSelect.java
+++ b/src/main/java/smallsql/database/CommandSelect.java
@@ -276,7 +276,7 @@ class CommandSelect extends Command{
 		if (from != null){
 			from.getColumns();
 			ArrayList<String[]> fromPairs = from.getColumns();
-			addFields(AccessType.JOIN.ordinal(), fromPairs);
+			addFields(AccessType.JOIN, fromPairs);
 		}
 	}
 
@@ -288,19 +288,19 @@ class CommandSelect extends Command{
 	public void postCompileGetColumns(){
     	if (where != null){
     		ArrayList<String[]> wherePairs = where.getColumns(false);
-    		addFields(AccessType.WHERE.ordinal(), wherePairs);
+    		addFields(AccessType.WHERE, wherePairs);
 		}
     	if (groupBy != null){
 			ArrayList<String[]> groupByPairs = groupBy.getColumns(false);
-			addFields(AccessType.GROUPBY.ordinal(), groupByPairs);
+			addFields(AccessType.GROUPBY, groupByPairs);
 		}
 		if (having != null){
 			ArrayList<String[]> havingPairs = having.getColumns(false);
-			addFields(AccessType.HAVING.ordinal(), havingPairs);
+			addFields(AccessType.HAVING, havingPairs);
 		}
 		if (orderBy != null){
 			ArrayList<String[]> orderByPairs = orderBy.getColumns(false);
-			addFields(AccessType.ORDERBY.ordinal(), orderByPairs);
+			addFields(AccessType.ORDERBY, orderByPairs);
 		}
 	}
     

--- a/src/main/java/smallsql/database/CommandUpdate.java
+++ b/src/main/java/smallsql/database/CommandUpdate.java
@@ -93,7 +93,7 @@ class CommandUpdate extends CommandSelect {
 	public void postCompileGetColumns(){
 		super.postCompileGetColumns();
 		ArrayList<String[]> setPairs = columnExpressions.getColumns(false);
-		addFields(AccessType.UPDATE.ordinal(), setPairs);
+		addFields(AccessType.UPDATE, setPairs);
 	}
 	
 	

--- a/src/main/java/smallsql/database/Field.java
+++ b/src/main/java/smallsql/database/Field.java
@@ -26,7 +26,13 @@ public class Field {
         StringBuilder builder = new StringBuilder();
         builder.append(tableName.toLowerCase());
         builder.append('.');
-        builder.append(fieldName.toLowerCase());
+        if (fieldName != null) {
+            builder.append(fieldName.toLowerCase());
+        } else {
+            // DELETE and INSERT commands have null as their fieldName.
+            // TODO: is there a better way to represent this?
+            builder.append("null");
+        }
         return builder.toString();
     }
 
@@ -35,23 +41,28 @@ public class Field {
         return Field.formatKey(tableName, fieldName);
     }
 
-    // operationID will be changed to an enum
-    public void incrementCounter(int operationType) throws Error {
-        switch (operationType) {
-            case 0:
+    public void incrementCounter(AccessType accessType) {
+        switch (accessType) {
+            case SELECT:
                 this.selections++;
                 break;
-            case 1: 
+            case DELETION: 
                 this.deletions++;
                 break;
-            case 2:
+            case INSERTION:
                 this.insertions++;
                 break;
-            case 3:
+            case JOIN:
                 this.joins++;
                 break;
-            default:
-                throw new Error("Unrecognized operationType: " + operationType);
+            case WHERE:
+            case UPDATE:
+            case GROUPBY:
+            case HAVING:
+            case ORDERBY:
+            case NULL:
+                // TODO: handle these
+                break;
         }
     }
 

--- a/src/main/java/smallsql/database/SQLParser.java
+++ b/src/main/java/smallsql/database/SQLParser.java
@@ -33,6 +33,7 @@
 package smallsql.database;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.sql.*;
 import smallsql.tools.language.Language;
 
@@ -337,7 +338,9 @@ final class SQLParser {
     }
     
     private CommandRecommendIndex recIndex() throws SQLException {
-        return new CommandRecommendIndex(con.log);
+        ArrayList<Field> fields = con.getFieldTracker().getFields();
+        IndexRecommender rec = new IndexRecommenderBasic(con, fields);
+        return new CommandRecommendIndex(con.log, rec);
     }
 
     /**

--- a/src/main/java/smallsql/database/SSConnection.java
+++ b/src/main/java/smallsql/database/SSConnection.java
@@ -83,6 +83,7 @@ public class SSConnection implements Connection {
         this.fieldTracker = new FieldTracker(con, con.database);
     }
 
+    
     public FieldTracker getFieldTracker() {
         return this.fieldTracker;
     }

--- a/src/main/java/smallsql/database/TrackerRecord.java
+++ b/src/main/java/smallsql/database/TrackerRecord.java
@@ -1,18 +1,18 @@
 package smallsql.database;
 
 public class TrackerRecord {
-    private int operationType;
+    private AccessType accessType;
     private String tableName;
     private String fieldName;
 
-    public TrackerRecord(int operationType, String tableName, String fieldName){
-        this.operationType = operationType;
+    public TrackerRecord(AccessType accessType, String tableName, String fieldName){
+        this.accessType = accessType;
         this.tableName = tableName;
         this.fieldName = fieldName;
     }
 
-    int getOperationType(){
-        return operationType;
+    AccessType getAccessType(){
+        return accessType;
     }
 
     String getTableName(){


### PR DESCRIPTION
Don't close this right away. I messed with a lot of stuff and probably broke some things.

Changes:
* using AccessType enum where appropriate, instead of operationType int
* CommandRecommendIndex creates an IndexRecommenderBasic object, then calls its recommendIndex() function
  * Can be called using REC_INDEX;
  * At the moment this just prints to console, but it should probably return an SSResultSet so the CLI can handle it instead
  * Should probably add another keyword to let the user choose different strategies, like REC_INDEX BASIC;
* To support this, added a getFields() method to FieldTracker
  * This returns fields from all tables. Might not be what we want?
* Changed a bunch of stuff around the codebase to fix random NullPointerExceptions and other stuff I was getting
  * There were a lot of issues with creating the field table, closing the database, etc
  * Some of these were a bit hacky, might want to look into better solutions